### PR TITLE
avoid potential DivideByZeroException in GenerateFinalStartingReads and in ExtendFromStartingReads

### DIFF
--- a/Kelpie_v2/Program.cs
+++ b/Kelpie_v2/Program.cs
@@ -5121,7 +5121,7 @@ namespace Kelpie
             int stillShortStartingReadsTotal = 0;
             int uncleanStartingReadsTotal = 0;
 
-            int partitionsToUse = Math.Min(1, Environment.ProcessorCount - 1);
+            int partitionsToUse = Math.Max(1, Environment.ProcessorCount - 1);
             int startingPartitionSize = readsWithStartingPrimers.Count / partitionsToUse;
             List<int> startingPartitionStarts = new List<int>();
             List<int> startingPartitionEnds = new List<int>();
@@ -5808,7 +5808,7 @@ namespace Kelpie
             int readsExtendedProgress = 0;
             Stopwatch sw = new Stopwatch();
 
-            int reportingInterval = Math.Min(1, startingReads.Count / 10);
+            int reportingInterval = Math.Max(1, startingReads.Count / 10);
 
             // convert the minReadLength to the max context length that will fit inside such as short read (index)
             int minViableContextIdx = 0;

--- a/Kelpie_v2/Program.cs
+++ b/Kelpie_v2/Program.cs
@@ -5121,7 +5121,7 @@ namespace Kelpie
             int stillShortStartingReadsTotal = 0;
             int uncleanStartingReadsTotal = 0;
 
-            int partitionsToUse = Environment.ProcessorCount - 1;
+            int partitionsToUse = Math.Min(1, Environment.ProcessorCount - 1);
             int startingPartitionSize = readsWithStartingPrimers.Count / partitionsToUse;
             List<int> startingPartitionStarts = new List<int>();
             List<int> startingPartitionEnds = new List<int>();
@@ -5808,7 +5808,7 @@ namespace Kelpie
             int readsExtendedProgress = 0;
             Stopwatch sw = new Stopwatch();
 
-            int reportingInterval = startingReads.Count / 10;
+            int reportingInterval = Math.Min(1, startingReads.Count / 10);
 
             // convert the minReadLength to the max context length that will fit inside such as short read (index)
             int minViableContextIdx = 0;


### PR DESCRIPTION
This should avoid two potential opportunities for DivideByZeroException.

In `GenerateFinalStartingReads`, if `Environment.ProcessorCount` is 1, then `partitionsToUse` becomes 0 and the calculation of `startingPartitionSize` results in a DivideByZeroException.

In `ExtendFromStartingReads`, if `startingReads.Count` is below 10, then `reportingInterval` becomes 0 and L5839 (specifically `readsExtendedProgress % reportingInterval`) triggers a DivideByZeroException.

I haven't tested this (I'm not compiling from source), but I believe these changes should resolve issues I've encountered when the environment reports a processor count of 1, or when the starting reads count is low.
